### PR TITLE
feat(card): add new Card component

### DIFF
--- a/src/app/components/card/card.module.css
+++ b/src/app/components/card/card.module.css
@@ -1,0 +1,44 @@
+.card {
+  width: 260px;
+  height: 180px;
+  padding: 20px;
+  border-radius: 16px;
+  background: radial-gradient(circle at top left, #1a1a1a, #0b0b0b);
+  box-shadow: 0 0 0 1px #1f1f1f;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 4px;                 
+}
+
+.icon {
+  color: #00451F;
+  font-size: 32px;
+ 
+}
+
+.title {
+  margin: 0;
+  padding: 0;
+  color: #fff;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.link {
+  color: #00A349;
+  text-decoration: none;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+}
+
+.baixo {
+display: flex;
+flex-direction: column;
+justify-content: space-between;
+}

--- a/src/app/components/card/card.tsx
+++ b/src/app/components/card/card.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+import styles from './card.module.css';
+
+type CardProps = {
+  title: string;
+  href: string;
+  icon: ReactNode;
+  children: ReactNode;
+};
+
+export function Card({ title, href, icon, children }: CardProps) {
+  return (
+    <div className={styles.card}>
+      <div className={styles.icon}>{icon}</div>
+      <div className={styles.baixo}>
+        <h3 className={styles.title}>{title}</h3>
+        <a href={href} className={styles.link}>
+          {children}
+        </a>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# feat(card): add new Card component

## Description
This PR introduces a new **Card component** to the project.

## Changes included
- Created `Card` component in `src/components/Card/`
- Supports `title`, `icon`, `href`, and `children` props
- Basic styling applied

## Purpose
Provide a reusable Card component for displaying content blocks with an optional icon and link.

## Testing
- Verified rendering in the app
- Props correctly display title, icon, and link
